### PR TITLE
🐛 [Fix] #51 - 스플래시페이지 로직 수정 

### DIFF
--- a/src/constants/routeConstants.ts
+++ b/src/constants/routeConstants.ts
@@ -1,5 +1,6 @@
 export const ROUTE_PATHS = {
-  MAP: "/",
+  SPLASH: "/",
+  MAP: "/map",
   ARTICLE: "/article",
   AI: "/ai",
   TALK: "/talk",

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -13,7 +13,7 @@ import MapControll from "./_components/MapControll";
 import { useLanguage } from "@/components/contexts/LanguageContext";
 // import { useResetGoogleMaps } from "./_hooks/useResetGoogleMap";
 
-import Loading from "@/pages/splash/SplashPage";
+import Loading from "@/pages/splash/Loading";
 import { useSearchParams } from "react-router-dom";
 const MapPage = () => {
   const [isPlaceInfo, setIsPlaceInfo] = useState<boolean>(false);
@@ -45,10 +45,10 @@ const MapPage = () => {
         return (
           <div
             style={{
-              position: "fixed",
-              top: 0,
-              left: "50%",
-              transform: "translateX(-50%)",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              flexGrow: "1",
               width: "100%",
               maxWidth: "540px",
               height: "100%",

--- a/src/pages/splash/SplashPage.tsx
+++ b/src/pages/splash/SplashPage.tsx
@@ -1,7 +1,20 @@
 import styled from "styled-components";
 import Loading from "./Loading";
 import { IMAGE_CONSTANTS } from "@/constants/imageConstants";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { ROUTE_PATHS } from "@/constants/routeConstants";
+
 const SplashPage = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate(ROUTE_PATHS.MAP, { replace: true });
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [navigate]);
   return (
     <Wrapper>
       <SplashImg src={IMAGE_CONSTANTS.splash} />
@@ -19,7 +32,7 @@ const Wrapper = styled.div`
   align-items: center;
   flex-direction: column;
   background-color: ${({ theme }) => theme.colors.WHITE};
-  z-index: 200;
+  z-index: 50;
   gap: 80px;
 `;
 const SplashImg = styled.img`

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -13,6 +13,7 @@ import TalkPage from "@/pages/talk/TalkPage";
 import TextTranslation from "@/pages/talk/_components/TextTranslation";
 import VoiceTranslation from "@/pages/talk/_components/VoiceTranslation";
 import NotFound from "@/pages/notFound/NotFound";
+import SplashPage from "@/pages/splash/SplashPage";
 const router = createBrowserRouter([
   {
     path: "/",
@@ -28,6 +29,7 @@ const router = createBrowserRouter([
       { path: `${ROUTE_PATHS.ARTICLE}/:id`, element: <ArticleDetailPage /> },
       { path: ROUTE_PATHS.TextTranslation, element: <TextTranslation /> },
       { path: ROUTE_PATHS.VoiceTranslation, element: <VoiceTranslation /> },
+      { path: ROUTE_PATHS.SPLASH, element: <SplashPage /> },
     ],
   },
 


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
기존에 map화면 랜더링될떄만나오던 스플래시페이지를 기본경로로 변경하고 2초뒤에 /map경로로 보내도록 수정했습니당. /map에서 로딩컴포넌트는 기존 로티만 있는거로 수정 


## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #51 
